### PR TITLE
Fixes for conflicts with Pawnmorpher

### DIFF
--- a/Source/GUI/Dialog_TagEditor.cs
+++ b/Source/GUI/Dialog_TagEditor.cs
@@ -604,7 +604,7 @@ namespace Inventory {
 
                 Widgets.DefIcon(descRect.LeftPart(.15f), def);
                 Widgets.Label(descRect.RightPart(.85f), def.LabelCap);
-                TooltipHandler.TipRegion(rowRect, () => def.DescriptionDetailed, def.index);
+                TooltipHandler.TipRegion(rowRect, () => def.DescriptionDetailed, def.GetHashCode());
 
                 if (Widgets.ButtonInvisible(descRect)) {
                     AddDefToTag(def);

--- a/Source/GUI/Dialog_TagEditor.cs
+++ b/Source/GUI/Dialog_TagEditor.cs
@@ -604,7 +604,7 @@ namespace Inventory {
 
                 Widgets.DefIcon(descRect.LeftPart(.15f), def);
                 Widgets.Label(descRect.RightPart(.85f), def.LabelCap);
-                TooltipHandler.TipRegion(rowRect, def.DescriptionDetailed);
+                TooltipHandler.TipRegion(rowRect, () => def.DescriptionDetailed, def.index);
 
                 if (Widgets.ButtonInvisible(descRect)) {
                     AddDefToTag(def);

--- a/Source/Patches/Notify_LoadedLevelChanged_Patch.cs
+++ b/Source/Patches/Notify_LoadedLevelChanged_Patch.cs
@@ -11,13 +11,14 @@ namespace Inventory {
         private static bool patchedDefs = false;
 
         private static void Postfix() {
-            if (patchedDefs) return;
+            if (patchedDefs) 
+				return;
 
-            foreach (var thing in DefDatabase<PawnKindDef>.AllDefs.Where(t => t.race.race.Humanlike)) {
-                var race = thing.race;
-                if (race.comps.Any(c => c.compClass == typeof(LoadoutComponent))) continue;
+            foreach (var thing in DefDatabase<ThingDef>.AllDefsListForReading.Where(t => t.race?.Humanlike == true)) {
+                if (thing.comps.Any(c => c.compClass == typeof(LoadoutComponent))) 
+					continue;
 
-                race.comps.Add(new CompProperties(typeof(LoadoutComponent)));
+				thing.comps.Add(new CompProperties(typeof(LoadoutComponent)));
             }
 
             Utility.CalculateDefLists();

--- a/Source/Utility/Utility.cs
+++ b/Source/Utility/Utility.cs
@@ -121,13 +121,12 @@ namespace Inventory {
         }
 
         public static bool IsValidLoadoutHolder(this Pawn pawn) {
-            return pawn.RaceProps.Humanlike
-                   && !pawn.RaceProps.Animal
-                   && pawn.IsColonist
-                   && !pawn.Dead
-                   && !pawn.IsQuestLodger()
-                   && !(pawn.apparel?.AnyApparelLocked ?? true)
-                   && !pawn.RaceProps.packAnimal; // for a mod which has animals which somehow pass all of the above criteria...
+			return pawn.RaceProps.Humanlike
+				   && !pawn.RaceProps.Animal
+				   && pawn.IsColonist
+				   && !pawn.Dead
+				   && !pawn.IsQuestLodger()
+				   && !(pawn.apparel?.AnyApparelLocked ?? true);
         }
 
         public static IEnumerable<Thing> InventoryAndEquipment(this Pawn pawn) {


### PR DESCRIPTION
The main source of issue is the component assignment being based on PawnKindDef specifically.
Morphs in PM are generated PawnDef, but don't have any PawnKindDef associated since they are managed in code and not intended to appear naturally.