### PR TITLE
improve 'Better Pawn Control' support

### DIFF
--- a/Source/Patches/BetterPawnControl_EmergencyToggle_Patch.cs
+++ b/Source/Patches/BetterPawnControl_EmergencyToggle_Patch.cs
@@ -20,7 +20,8 @@ namespace Inventory
         public static void TryPatch(Harmony harmonyInstance)
         {
             var bpcLoaded = LoadedModManager.RunningModsListForReading.Any(m => m.PackageId.ToLowerInvariant() == "VouLT.BetterPawnControl".ToLowerInvariant());
-            if ( bpcLoaded && !patched ) {
+            bool oldBpc = AccessTools.PropertyGetter("BetterPawnControl.Widget_ModsAvailable:CompositableAvailable") == null;
+            if ( bpcLoaded && !patched && oldBpc ) {
                 var method = AccessTools.Method("BetterPawnControl.Patches.PlaySettings_DoPlaySettingsGlobalControls:EmergencyToogleON");
                 harmonyInstance.Patch(method, postfix: new HarmonyMethod(typeof(BetterPawnControl_EmergencyToggle_Patch), nameof(ToggleOn)));
                 

--- a/Source/Patches/BetterPawnControl_EmergencyToggle_Patch.cs
+++ b/Source/Patches/BetterPawnControl_EmergencyToggle_Patch.cs
@@ -16,28 +16,48 @@ namespace Inventory
     static class BetterPawnControl_EmergencyToggle_Patch
     {
         private static bool patched = false;
+        public static bool emergencyActive = false;
 
         public static void TryPatch(Harmony harmonyInstance)
         {
             var bpcLoaded = LoadedModManager.RunningModsListForReading.Any(m => m.PackageId.ToLowerInvariant() == "VouLT.BetterPawnControl".ToLowerInvariant());
-            bool oldBpc = AccessTools.PropertyGetter("BetterPawnControl.Widget_ModsAvailable:CompositableAvailable") == null;
-            if ( bpcLoaded && !patched && oldBpc ) {
-                var method = AccessTools.Method("BetterPawnControl.Patches.PlaySettings_DoPlaySettingsGlobalControls:EmergencyToogleON");
-                harmonyInstance.Patch(method, postfix: new HarmonyMethod(typeof(BetterPawnControl_EmergencyToggle_Patch), nameof(ToggleOn)));
-                
-                method = AccessTools.Method("BetterPawnControl.Patches.PlaySettings_DoPlaySettingsGlobalControls:EmergencyToogleOFF");
-                harmonyInstance.Patch(method, postfix: new HarmonyMethod(typeof(BetterPawnControl_EmergencyToggle_Patch), nameof(ToggleOff)));
-                patched = true;
+            if ( bpcLoaded && !patched ) {
+                if( AccessTools.PropertyGetter("BetterPawnControl.Widget_ModsAvailable:CompositableAvailable") != null ) {
+                    // New BPC switches loadouts as part of emergency mode switching,
+                    // so only set flag to force immediate resolving before BPC switches the loadouts.
+                    var method = AccessTools.Method("BetterPawnControl.Patches.PlaySettings_DoPlaySettingsGlobalControls:EmergencyToogleON");
+                    harmonyInstance.Patch(method, prefix: new HarmonyMethod(typeof(BetterPawnControl_EmergencyToggle_Patch), nameof(ToggleOnNew)));
 
-                Log.Message("[Loadout Compositing] Enabled mod integrations with Better Pawn Control");
+                    method = AccessTools.Method("BetterPawnControl.Patches.PlaySettings_DoPlaySettingsGlobalControls:EmergencyToogleOFF");
+                    harmonyInstance.Patch(method, prefix: new HarmonyMethod(typeof(BetterPawnControl_EmergencyToggle_Patch), nameof(ToggleOffNew)));
+
+                    Log.Message("[Loadout Compositing] Enabled mod integrations with Better Pawn Control (new mode)");
+                } else {
+                    var method = AccessTools.Method("BetterPawnControl.Patches.PlaySettings_DoPlaySettingsGlobalControls:EmergencyToogleON");
+                    harmonyInstance.Patch(method, postfix: new HarmonyMethod(typeof(BetterPawnControl_EmergencyToggle_Patch), nameof(ToggleOnOld)));
+
+                    method = AccessTools.Method("BetterPawnControl.Patches.PlaySettings_DoPlaySettingsGlobalControls:EmergencyToogleOFF");
+                    harmonyInstance.Patch(method, postfix: new HarmonyMethod(typeof(BetterPawnControl_EmergencyToggle_Patch), nameof(ToggleOffOld)));
+
+                    Log.Message("[Loadout Compositing] Enabled mod integrations with Better Pawn Control");
+                }
+                patched = true;
             }
         }
 
-        public static void ToggleOn() {
+        public static void ToggleOnNew() {
+            emergencyActive = true;
+        }
+
+        public static void ToggleOffNew() {
+            emergencyActive = false;
+        }
+
+        public static void ToggleOnOld() {
             LoadoutManager.TogglePanicMode(true);
         }
 
-        public static void ToggleOff() {
+        public static void ToggleOffOld() {
             LoadoutManager.TogglePanicMode(false);
         }
     }

--- a/Source/Utility/BetterPawnControl.cs
+++ b/Source/Utility/BetterPawnControl.cs
@@ -12,11 +12,11 @@ namespace Inventory {
         public static void SetLoadoutById(Pawn pawn, int id) {
             foreach( LoadoutState state in LoadoutManager.States ) {
                 if( state.id == id) {
-                    pawn.SetActiveState(state);
+                    pawn.SetActiveState(state, immediatelyResolve: BetterPawnControl_EmergencyToggle_Patch.emergencyActive);
                     return;
                 }
             }
-            pawn.SetActiveState(null);
+            pawn.SetActiveState(null, immediatelyResolve: BetterPawnControl_EmergencyToggle_Patch.emergencyActive);
         }
     }
 }

--- a/Source/Utility/BetterPawnControl.cs
+++ b/Source/Utility/BetterPawnControl.cs
@@ -1,0 +1,22 @@
+﻿using Verse;
+
+namespace Inventory {
+
+    // Support for Better Pawn Control mod to get/set an active loadout for a pawn.
+    public static class BetterPawnControl {
+
+        public static int GetLoadoutId(Pawn pawn) {
+            return pawn.GetActiveState()?.id ?? -1;
+        }
+
+        public static void SetLoadoutById(Pawn pawn, int id) {
+            foreach( LoadoutState state in LoadoutManager.States ) {
+                if( state.id == id) {
+                    pawn.SetActiveState(state);
+                    return;
+                }
+            }
+            pawn.SetActiveState(null);
+        }
+    }
+}


### PR DESCRIPTION
Binding only the panic state to the alert button of BPC leads to an inconsistent experience - the primary functionality of BPC is to switch policies and the alert button merely enables/reverts a specific policy. It should be the same as activating the relevant policies manually, but that did not work.

This patch makes BPC fully responsible for setting the loadout state when the alert button is activated, and also makes BPC handle properly set loadout states when BPC policy is changed. Requires support in BPC (submitted there).